### PR TITLE
Implement graders API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 - DALL-E integration for image generation
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
+- Grader API support for validating and running graders
 
 ## Installation
 
@@ -87,7 +88,42 @@ func _ready():
 	open_ai.connect("dalle_response_completed", dalle_response_completed)
 
 func _on_dalle_response(texture: ImageTexture):
-	$Sprite2D.texture = texture
+        $Sprite2D.texture = texture
+```
+
+### Using Graders
+
+The plugin also provides helper methods for the Graders API. To validate a grader configuration:
+
+```gdscript
+var grader = {"type": "string_check", "input": "{{sample.output_text}}", "reference": "{{item.label}}", "operation": "eq"}
+openai.validate_grader(grader)
+```
+
+Listen for the response:
+
+```gdscript
+func _ready():
+        open_ai.connect("grader_validate_completed", _on_grader_validate)
+
+func _on_grader_validate(response: Dictionary):
+        print(response)
+```
+
+To run a grader against a model answer:
+
+```gdscript
+openai.run_grader(grader, "model output", {"label": "expected output"})
+```
+
+Handle the result:
+
+```gdscript
+func _ready():
+        open_ai.connect("grader_run_completed", _on_grader_run)
+
+func _on_grader_run(response: Dictionary):
+        print(response)
 ```
 
 ## Classes
@@ -107,3 +143,7 @@ Handles ChatGPT API requests.
 ### Dalle
 
 Handles DALL-E API requests.
+
+### Grader
+
+Provides helper methods for the Graders API.

--- a/addons/openai_api/Scenes/Grader.tscn
+++ b/addons/openai_api/Scenes/Grader.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource type="Script" path="res://addons/openai_api/Scripts/Grader.gd" id="1_fgrdr"]
+
+[node name="Grader" type="Node"]
+script = ExtResource("1_fgrdr")

--- a/addons/openai_api/Scripts/Grader.gd
+++ b/addons/openai_api/Scripts/Grader.gd
@@ -1,0 +1,74 @@
+extends Node
+class_name Grader
+
+var http_request_run: HTTPRequest
+var http_request_validate: HTTPRequest
+
+@onready var parent = get_parent()
+
+func _ready():
+        http_request_run = HTTPRequest.new()
+        add_child(http_request_run)
+        http_request_run.request_completed.connect(self._run_completed)
+        http_request_validate = HTTPRequest.new()
+        add_child(http_request_validate)
+        http_request_validate.request_completed.connect(self._validate_completed)
+
+func run_grader(grader: Dictionary, model_sample: String, item: Dictionary = {}, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
+        var openai_api_key = parent.get_api()
+        if !openai_api_key:
+                return
+        var headers = [
+                "Content-Type: application/json",
+                "Authorization: Bearer " + openai_api_key
+        ]
+        var body: Dictionary = {
+                "grader": grader,
+                "model_sample": model_sample
+        }
+        if item.size() > 0:
+                body["item"] = item
+        var json = JSON.new()
+        var body_json = json.stringify(body)
+        var error = http_request_run.request(url, headers, HTTPClient.METHOD_POST, body_json)
+        if error != OK:
+                push_error("An error occurred in the HTTP request.")
+
+func validate_grader(grader: Dictionary, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/validate"):
+        var openai_api_key = parent.get_api()
+        if !openai_api_key:
+                return
+        var headers = [
+                "Content-Type: application/json",
+                "Authorization: Bearer " + openai_api_key
+        ]
+        var body = {"grader": grader}
+        var json = JSON.new()
+        var body_json = json.stringify(body)
+        var error = http_request_validate.request(url, headers, HTTPClient.METHOD_POST, body_json)
+        if error != OK:
+                push_error("An error occurred in the HTTP request.")
+
+func _run_completed(result, response_code, headers, body):
+        if result != HTTPRequest.RESULT_SUCCESS:
+                push_error("Error with the request.")
+                return
+        var json = JSON.new()
+        var error = json.parse(body.get_string_from_utf8())
+        if error != OK:
+                push_error("Error parsing response.")
+                return
+        var response = json.get_data()
+        parent.emit_signal("grader_run_completed", response)
+
+func _validate_completed(result, response_code, headers, body):
+        if result != HTTPRequest.RESULT_SUCCESS:
+                push_error("Error with the request.")
+                return
+        var json = JSON.new()
+        var error = json.parse(body.get_string_from_utf8())
+        if error != OK:
+                push_error("Error parsing response.")
+                return
+        var response = json.get_data()
+        parent.emit_signal("grader_validate_completed", response)

--- a/addons/openai_api/Scripts/OpenAiApi.gd
+++ b/addons/openai_api/Scripts/OpenAiApi.gd
@@ -3,14 +3,18 @@ extends Node
 
 var chatgpt_inst = preload("res://addons/openai_api/Scenes/ChatGpt.tscn")
 var dalle_inst = preload("res://addons/openai_api/Scenes/Dalle.tscn")
+var grader_inst = preload("res://addons/openai_api/Scenes/Grader.tscn")
 
 @export var dalle :Dalle = null
 @export var chatgpt :ChatGpt = null
+@export var grader :Grader = null
 
 @export var openai_api_key = ""
 
 signal gpt_response_completed(message:Message, response:Dictionary)
 signal dalle_response_completed(texture:ImageTexture)
+signal grader_run_completed(response:Dictionary)
+signal grader_validate_completed(response:Dictionary)
 
 ##Makes an api call to open ai chatgpt, and returns a class `Message` that contains `{"role":role,"content":content}`
 func prompt_gpt(ListOfMessages:Array[Message], model: String = "gpt-o-mini", url:String="https://api.openai.com/v1/chat/completions"):
@@ -22,11 +26,27 @@ func prompt_gpt(ListOfMessages:Array[Message], model: String = "gpt-o-mini", url
 
 ##Makes an api call to open ai dalle, and returns the generated Texture
 func prompt_dalle(prompt:String, resolution:String = "1024x1024", model: String = "dall-e-2", url:String="https://api.openai.com/v1/images/generations"):
-	
-	while !dalle:
-		await get_tree().create_timer(0.2).timeout
-		
-	dalle.prompt_dalle(prompt,resolution,model,url)
+
+		while !dalle:
+				await get_tree().create_timer(0.2).timeout
+
+		dalle.prompt_dalle(prompt,resolution,model,url)
+
+##Runs a grader and returns the result dictionary
+func run_grader(grader_dict:Dictionary, model_sample:String, item:Dictionary = {}, url:String="https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
+
+		while !grader:
+				await get_tree().create_timer(0.2).timeout
+
+		grader.run_grader(grader_dict, model_sample, item, url)
+
+##Validates a grader and returns the validation dictionary
+func validate_grader(grader_dict:Dictionary, url:String="https://api.openai.com/v1/fine_tuning/alpha/graders/validate"):
+
+		while !grader:
+				await get_tree().create_timer(0.2).timeout
+
+		grader.validate_grader(grader_dict, url)
 
 func get_api() -> String:
 	if openai_api_key.is_empty():
@@ -37,17 +57,20 @@ func set_api(api:String) -> void:
 	openai_api_key = api
 
 func _ready():
-	if chatgpt and dalle:
-		return
-		
-	call_deferred("add_child",chatgpt_inst.instantiate())
-	call_deferred("add_child",dalle_inst.instantiate())
+		if chatgpt and dalle and grader:
+				return
+
+		call_deferred("add_child",chatgpt_inst.instantiate())
+		call_deferred("add_child",dalle_inst.instantiate())
+		call_deferred("add_child",grader_inst.instantiate())
 	
 func _process(delta):
-	if dalle and chatgpt:
-		set_process(false)
-	if get_children() == []:
-		return
-		
-	chatgpt = get_children()[0]
-	dalle = get_children()[1]
+		if dalle and chatgpt and grader:
+				set_process(false)
+		if get_children() == []:
+				return
+
+		chatgpt = get_children()[0]
+		dalle = get_children()[1]
+		if get_child_count() > 2:
+				grader = get_children()[2]


### PR DESCRIPTION
## Summary
- integrate OpenAI graders API
- add new `Grader` node with run and validate methods
- expose `run_grader` and `validate_grader` on `OpenAiApi`
- update documentation with usage instructions
- fix indentation so the plugin loads in Godot

## Testing
- `godot --headless --editor --quit --path .`


------
https://chatgpt.com/codex/tasks/task_e_687b68f1106483209de89c345f796923