### PR TITLE
Add graders API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 - DALL-E integration for image generation
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
+- Run and validate graders for fine-tuning workflows
 
 ## Installation
 

--- a/addons/openai_api/Scenes/Grader.tscn
+++ b/addons/openai_api/Scenes/Grader.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://7zenlyqfrls"]
+
+[ext_resource type="Script" uid="uid://mwyko5fjbwg" path="res://addons/openai_api/Scripts/Grader.gd" id="1_rdrgr"]
+
+[node name="Grader" type="Node"]
+script = ExtResource("1_rdrgr")

--- a/addons/openai_api/Scripts/Chat.gd
+++ b/addons/openai_api/Scripts/Chat.gd
@@ -1,6 +1,7 @@
 extends Node
 class_name ChatGpt
 var http_request: HTTPRequest
+const Message = preload("res://addons/openai_api/Scripts/Message.gd")
 ## Automaticly gets the api from the global script `OpenAi`
 
 @onready var parent = get_parent()

--- a/addons/openai_api/Scripts/Grader.gd
+++ b/addons/openai_api/Scripts/Grader.gd
@@ -1,0 +1,75 @@
+extends Node
+class_name Grader
+
+var http_request_run: HTTPRequest
+var http_request_validate: HTTPRequest
+
+@onready var parent = get_parent()
+
+func _ready():
+	http_request_run = HTTPRequest.new()
+	add_child(http_request_run)
+	http_request_run.request_completed.connect(self._run_request_completed)
+
+	http_request_validate = HTTPRequest.new()
+	add_child(http_request_validate)
+	http_request_validate.request_completed.connect(self._validate_request_completed)
+
+func run_grader(grader: Dictionary, model_sample: String, item: Dictionary = {}, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
+	var openai_api_key = parent.get_api()
+	if !openai_api_key:
+		return
+	var headers = [
+		"Content-Type: application/json",
+		"Authorization: Bearer " + openai_api_key
+	]
+	var body = {
+		"grader": grader,
+		"model_sample": model_sample
+	}
+	if !item.is_empty():
+		body["item"] = item
+	var json = JSON.new()
+	var body_json = json.stringify(body)
+	var error = http_request_run.request(url, headers, HTTPClient.METHOD_POST, body_json)
+	if error != OK:
+		push_error("An error occurred in the HTTP request.")
+
+func validate_grader(grader: Dictionary, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/validate"):
+	var openai_api_key = parent.get_api()
+	if !openai_api_key:
+		return
+	var headers = [
+		"Content-Type: application/json",
+		"Authorization: Bearer " + openai_api_key
+	]
+	var body = {"grader": grader}
+	var json = JSON.new()
+	var body_json = json.stringify(body)
+	var error = http_request_validate.request(url, headers, HTTPClient.METHOD_POST, body_json)
+	if error != OK:
+		push_error("An error occurred in the HTTP request.")
+
+func _run_request_completed(result, response_code, headers, body):
+	if result != HTTPRequest.RESULT_SUCCESS:
+		push_error("Error with the request.")
+		return
+	var json = JSON.new()
+	var error = json.parse(body.get_string_from_utf8())
+	if error != OK:
+		push_error("Error parsing response.")
+		return
+	var response = json.get_data()
+	parent.emit_signal("grader_run_completed", response)
+
+func _validate_request_completed(result, response_code, headers, body):
+	if result != HTTPRequest.RESULT_SUCCESS:
+		push_error("Error with the request.")
+		return
+	var json = JSON.new()
+	var error = json.parse(body.get_string_from_utf8())
+	if error != OK:
+		push_error("Error parsing response.")
+		return
+	var response = json.get_data()
+	parent.emit_signal("grader_validation_completed", response)

--- a/addons/openai_api/Scripts/Grader.gd.uid
+++ b/addons/openai_api/Scripts/Grader.gd.uid
@@ -1,0 +1,1 @@
+uid://mwyko5fjbwg

--- a/addons/openai_api/Scripts/OpenAiApi.gd
+++ b/addons/openai_api/Scripts/OpenAiApi.gd
@@ -4,16 +4,20 @@ extends Node
 var chatgpt_inst = preload("res://addons/openai_api/Scenes/ChatGpt.tscn")
 var dalle_inst = preload("res://addons/openai_api/Scenes/Dalle.tscn")
 var models_inst = preload("res://addons/openai_api/Scenes/Models.tscn")
+var grader_inst = preload("res://addons/openai_api/Scenes/Grader.tscn")
 
 @export var dalle :Dalle = null
 @export var chatgpt :ChatGpt = null
 @export var models: Models = null
+@export var grader: Grader = null
 
 @export var openai_api_key = ""
 
 signal gpt_response_completed(message:Message, response:Dictionary)
 signal dalle_response_completed(texture:ImageTexture)
 signal models_received(models: Array[String])
+signal grader_run_completed(response: Dictionary)
+signal grader_validation_completed(response: Dictionary)
 
 ##Makes an api call to open ai chatgpt, and returns a class `Message` that contains `{"role":role,"content":content}`
 func prompt_gpt(ListOfMessages:Array[Message], model: String = "gpt-4o-mini", url:String="https://api.openai.com/v1/chat/completions", tools:Array = []):
@@ -31,6 +35,20 @@ func prompt_dalle(prompt:String, resolution:String = "1024x1024", model: String 
 		
 	dalle.prompt_dalle(prompt,resolution,model,url)
 
+func run_grader(grader_obj: Dictionary, model_sample: String, item: Dictionary = {}, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
+
+	while !grader:
+		await get_tree().create_timer(0.2).timeout
+
+	grader.run_grader(grader_obj, model_sample, item, url)
+
+func validate_grader(grader_obj: Dictionary, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/validate"):
+
+	while !grader:
+		await get_tree().create_timer(0.2).timeout
+
+	grader.validate_grader(grader_obj, url)
+
 func get_api() -> String:
 	if openai_api_key.is_empty():
 		push_error("Insert your OpenAi api key!")
@@ -46,19 +64,21 @@ func get_models() -> void:
 	models.get_available_models()
 
 func _ready():
-	if chatgpt and dalle and models:
+	if chatgpt and dalle and models and grader:
 		return
-		
+
 	call_deferred("add_child", chatgpt_inst.instantiate())
 	call_deferred("add_child", dalle_inst.instantiate())
 	call_deferred("add_child", models_inst.instantiate())
+	call_deferred("add_child", grader_inst.instantiate())
 	
 func _process(delta):
-	if dalle and chatgpt and models:
+	if dalle and chatgpt and models and grader:
 		set_process(false)
 	if get_children() == []:
 		return
-		
+
 	chatgpt = get_children()[0]
 	dalle = get_children()[1]
 	models = get_children()[2]
+	grader = get_children()[3]

--- a/addons/openai_api/Scripts/readme.md
+++ b/addons/openai_api/Scripts/readme.md
@@ -8,6 +8,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 - DALL-E integration for image generation
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
+- Support for OpenAI graders API
 
 ## Installation
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,0 +1,8 @@
+import subprocess
+import sys
+
+cmd = ['godot', '--headless', '-s', 'tests/test_grader.gd']
+print('Running:', ' '.join(cmd))
+result = subprocess.run(cmd)
+print('Godot exited with', result.returncode)
+sys.exit(result.returncode)

--- a/tests/test_grader.gd
+++ b/tests/test_grader.gd
@@ -1,0 +1,56 @@
+extends SceneTree
+class FakeParent:
+	extends Node
+	var api_key = ""
+	signal grader_run_completed(response: Dictionary)
+	signal grader_validation_completed(response: Dictionary)
+	func get_api():
+		return api_key
+var GraderScript = load("res://addons/openai_api/Scripts/Grader.gd")
+var parent_node : FakeParent
+var grader
+func _initialize():
+	var key = OS.get_environment("OPENAI_API_KEY")
+	if key == "":
+		print("Skipping grader tests: OPENAI_API_KEY not set")
+		quit(0)
+		return
+	parent_node = FakeParent.new()
+	parent_node.api_key = key
+	get_root().add_child(parent_node)
+	grader = GraderScript.new()
+	parent_node.add_child(grader)
+	await self.process_frame
+	parent_node.grader_validation_completed.connect(_on_validate)
+	parent_node.grader_run_completed.connect(_on_run)
+	var g = {
+		"type": "string_check",
+		"name": "Example string check grader",
+		"input": "{{sample.output_text}}",
+		"reference": "{{item.label}}",
+		"operation": "eq"
+	}
+	grader.validate_grader(g)
+func _on_validate(response: Dictionary) -> void:
+	if not response.has("grader"):
+		push_error("Validation failed: %s" % [response])
+		quit(1)
+		return
+	_run_test()
+func _run_test():
+	var g = {
+		"type": "string_check",
+		"name": "Example string check grader",
+		"input": "{{sample.output_text}}",
+		"reference": "{{item.label}}",
+		"operation": "eq"
+	}
+	var item = {"label": "foo"}
+	grader.run_grader(g, "foo", item)
+func _on_run(response: Dictionary) -> void:
+	if response.get("reward", -1) == -1:
+		push_error("Run failed: %s" % [response])
+		quit(1)
+		return
+	print("All tests passed")
+	quit(0)


### PR DESCRIPTION
## Summary
- fix script parsing issues
- add constant load for Message in ChatGpt
- provide sample tests for the new graders API
- refine grader implementation and switch tests to real API with skip if no key

## Testing
- `python3 tests/run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_687b6f7762f88320aa783d87aa062bcb