### PR TITLE
Add embeddings API support to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 
 - ChatGPT integration for text generation
 - DALL-E integration for image generation
+- Embeddings integration for vector representations
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
 - Run and validate graders for fine-tuning workflows
@@ -108,3 +109,22 @@ Handles ChatGPT API requests.
 ### Dalle
 
 Handles DALL-E API requests.
+
+### Using Embeddings
+
+To get an embedding vector for a piece of text:
+
+```gdscript
+openai.create_embedding("Your text here")
+```
+
+Listen for the response:
+
+```gdscript
+func _ready():
+	open_ai.connect("embedding_received", _on_embedding)
+
+func _on_embedding(embedding: Array, response: Dictionary):
+	print(embedding.size())
+```
+

--- a/addons/openai_api/Scenes/Embeddings.tscn
+++ b/addons/openai_api/Scenes/Embeddings.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://pmnncj0dfigq9"]
+
+[ext_resource type="Script" uid="uid://z43fkiv9wtuw5" path="res://addons/openai_api/Scripts/Embeddings.gd" id="1_dl0ii"]
+
+[node name="Embeddings" type="Node"]
+script = ExtResource("1_dl0ii")

--- a/addons/openai_api/Scripts/Embeddings.gd
+++ b/addons/openai_api/Scripts/Embeddings.gd
@@ -1,0 +1,43 @@
+extends Node
+class_name Embeddings
+var http_request: HTTPRequest
+
+@onready var parent = get_parent()
+
+func _ready():
+	http_request = HTTPRequest.new()
+	add_child(http_request)
+	http_request.request_completed.connect(self._http_request_completed)
+
+func create_embedding(input_text:String, model:String="text-embedding-3-small", url:String="https://api.openai.com/v1/embeddings"):
+	var openai_api_key = parent.get_api()
+	if !openai_api_key:
+		return
+	var headers = [
+		"Content-Type: application/json",
+		"Authorization: Bearer " + openai_api_key
+	]
+	var body = {
+		"model": model,
+		"input": input_text,
+		"encoding_format": "float"
+	}
+	var json = JSON.new()
+	var body_json = json.stringify(body)
+	var error = http_request.request(url, headers, HTTPClient.METHOD_POST, body_json)
+	if error != OK:
+		push_error("An error occurred in the HTTP request.")
+
+func _http_request_completed(result, response_code, headers, body):
+	if result != HTTPRequest.RESULT_SUCCESS:
+		push_error("Error with the request.")
+		return
+	var json = JSON.new()
+	var error = json.parse(body.get_string_from_utf8())
+	if error != OK:
+		push_error("Error parsing response.")
+		return
+	var response = json.get_data()
+	if response.has("data") and response["data"].size() > 0 and response["data"][0].has("embedding"):
+		var embedding = response["data"][0]["embedding"]
+		parent.emit_signal("embedding_received", embedding, response)

--- a/addons/openai_api/Scripts/Embeddings.gd.uid
+++ b/addons/openai_api/Scripts/Embeddings.gd.uid
@@ -1,0 +1,1 @@
+uid://z43fkiv9wtuw5

--- a/addons/openai_api/Scripts/OpenAiApi.gd
+++ b/addons/openai_api/Scripts/OpenAiApi.gd
@@ -5,17 +5,20 @@ var chatgpt_inst = preload("res://addons/openai_api/Scenes/ChatGpt.tscn")
 var dalle_inst = preload("res://addons/openai_api/Scenes/Dalle.tscn")
 var models_inst = preload("res://addons/openai_api/Scenes/Models.tscn")
 var grader_inst = preload("res://addons/openai_api/Scenes/Grader.tscn")
+var embeddings_inst = preload("res://addons/openai_api/Scenes/Embeddings.tscn")
 
 @export var dalle :Dalle = null
 @export var chatgpt :ChatGpt = null
 @export var models: Models = null
 @export var grader: Grader = null
+@export var embeddings: Embeddings = null
 
 @export var openai_api_key = ""
 
 signal gpt_response_completed(message:Message, response:Dictionary)
 signal dalle_response_completed(texture:ImageTexture)
 signal models_received(models: Array[String])
+signal embedding_received(embedding: Array, response: Dictionary)
 signal grader_run_completed(response: Dictionary)
 signal grader_validation_completed(response: Dictionary)
 
@@ -35,6 +38,11 @@ func prompt_dalle(prompt:String, resolution:String = "1024x1024", model: String 
 		
 	dalle.prompt_dalle(prompt,resolution,model,url)
 
+
+func create_embedding(input_text:String, model:String = "text-embedding-3-small", url:String="https://api.openai.com/v1/embeddings"):
+	while !embeddings:
+		await get_tree().create_timer(0.2).timeout
+	embeddings.create_embedding(input_text, model, url)
 func run_grader(grader_obj: Dictionary, model_sample, item = null, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
 	while !grader:
 		await get_tree().create_timer(0.2).timeout
@@ -66,16 +74,17 @@ func get_models() -> void:
 	models.get_available_models()
 
 func _ready():
-	if chatgpt and dalle and models and grader:
+	if chatgpt and dalle and models and grader and embeddings:
 		return
 
 	call_deferred("add_child", chatgpt_inst.instantiate())
 	call_deferred("add_child", dalle_inst.instantiate())
 	call_deferred("add_child", models_inst.instantiate())
 	call_deferred("add_child", grader_inst.instantiate())
+	call_deferred("add_child", embeddings_inst.instantiate())
 	
 func _process(delta):
-	if chatgpt and dalle and models and grader:
+	if chatgpt and dalle and models and grader and embeddings:
 		set_process(false)
 		return
 	for child in get_children():
@@ -87,3 +96,5 @@ func _process(delta):
 			models = child
 		elif !grader and child is Grader:
 			grader = child
+		elif !embeddings and child is Embeddings:
+			embeddings = child

--- a/addons/openai_api/Scripts/readme.md
+++ b/addons/openai_api/Scripts/readme.md
@@ -6,6 +6,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 
 - ChatGPT integration for text generation
 - DALL-E integration for image generation
+- Embeddings integration for vector representations
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
 - Support for OpenAI graders API
@@ -94,3 +95,22 @@ Handles DALL-E API requests.
 ## Support
 
 [Include support information here]
+
+### Using Embeddings
+
+To get an embedding vector for a piece of text:
+
+```gdscript
+openai.create_embedding("Your text here")
+```
+
+Listen for the response:
+
+```gdscript
+func _ready():
+	openai.embedding_received.connect(_on_embedding)
+
+func _on_embedding(embedding: Array, response: Dictionary):
+	print(embedding.size())
+```
+


### PR DESCRIPTION
## Summary
- add new `Embeddings` node to request vector embeddings from OpenAI
- expose `create_embedding` helper and `embedding_received` signal on `OpenAiApi`
- document embeddings usage in README

## Testing
- `godot -e --headless --path . --quit-after 2`
- `OPENAI_API_KEY= python tests/run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_68a42e77cab08320b8dc9bf4a9e9fc78