### PR TITLE
Add embeddings API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 
 - ChatGPT integration for text generation
 - DALL-E integration for image generation
+- Embeddings API for vector generation
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
 - Run and validate graders for fine-tuning workflows
@@ -91,6 +92,24 @@ func _on_dalle_response(texture: ImageTexture):
 	$Sprite2D.texture = texture
 ```
 
+
+### Using Embeddings
+
+To generate an embedding vector from text:
+
+```gdscript
+openai.get_embedding("A sample sentence")
+```
+
+Listen for the response:
+
+```gdscript
+func _ready():
+	openai.embedding_received.connect(self._on_embedding)
+
+func _on_embedding(embedding: Array, response: Dictionary):
+	print(embedding)
+```
 ## Classes
 
 ### OpenAI

--- a/addons/openai_api/Scenes/Embeddings.tscn
+++ b/addons/openai_api/Scenes/Embeddings.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3 uid="uid://wjg88llb5guh"]
+
+[ext_resource type="Script" uid="uid://oaxzxc5kho61" path="res://addons/openai_api/Scripts/Embeddings.gd" id="1_21edb"]
+
+[node name="Embeddings" type="Node"]
+script = ExtResource("1_21edb")

--- a/addons/openai_api/Scripts/Embeddings.gd
+++ b/addons/openai_api/Scripts/Embeddings.gd
@@ -1,0 +1,43 @@
+extends Node
+class_name Embeddings
+
+var http_request: HTTPRequest
+@onready var parent = get_parent()
+
+func _ready():
+	# Create HTTPRequest node
+	http_request = HTTPRequest.new()
+	add_child(http_request)
+	http_request.request_completed.connect(self._http_request_completed)
+
+func get_embedding(input_text:String, model:String = "text-embedding-3-small", url:String = "https://api.openai.com/v1/embeddings"):
+	var openai_api_key = parent.get_api()
+	if !openai_api_key:
+		return
+	var headers = [
+		"Content-Type: application/json",
+		"Authorization: Bearer " + openai_api_key
+	]
+	var body = {
+		"model": model,
+		"input": input_text
+	}
+	var json = JSON.new()
+	var body_json = json.stringify(body)
+	var error = http_request.request(url, headers, HTTPClient.METHOD_POST, body_json)
+	if error != OK:
+		push_error("An error occurred in the HTTP request.")
+
+func _http_request_completed(result, response_code, headers, body):
+	if result != HTTPRequest.RESULT_SUCCESS:
+		push_error("Error with the request.")
+		return
+	var json = JSON.new()
+	var parse_error = json.parse(body.get_string_from_utf8())
+	if parse_error != OK:
+		push_error("Error parsing response.")
+		return
+	var response = json.get_data()
+	if response.has("data") and response["data"].size() > 0 and response["data"][0].has("embedding"):
+		var embedding = response["data"][0]["embedding"]
+		parent.emit_signal("embedding_received", embedding, response)

--- a/addons/openai_api/Scripts/Embeddings.gd.uid
+++ b/addons/openai_api/Scripts/Embeddings.gd.uid
@@ -1,0 +1,1 @@
+uid://oaxzxc5kho61

--- a/addons/openai_api/Scripts/OpenAiApi.gd
+++ b/addons/openai_api/Scripts/OpenAiApi.gd
@@ -5,11 +5,13 @@ var chatgpt_inst = preload("res://addons/openai_api/Scenes/ChatGpt.tscn")
 var dalle_inst = preload("res://addons/openai_api/Scenes/Dalle.tscn")
 var models_inst = preload("res://addons/openai_api/Scenes/Models.tscn")
 var grader_inst = preload("res://addons/openai_api/Scenes/Grader.tscn")
+var embeddings_inst = preload("res://addons/openai_api/Scenes/Embeddings.tscn")
 
 @export var dalle :Dalle = null
 @export var chatgpt :ChatGpt = null
 @export var models: Models = null
 @export var grader: Grader = null
+@export var embeddings: Embeddings = null
 
 @export var openai_api_key = ""
 
@@ -18,6 +20,7 @@ signal dalle_response_completed(texture:ImageTexture)
 signal models_received(models: Array[String])
 signal grader_run_completed(response: Dictionary)
 signal grader_validation_completed(response: Dictionary)
+signal embedding_received(embedding: Array, response: Dictionary)
 
 ##Makes an api call to open ai chatgpt, and returns a class `Message` that contains `{"role":role,"content":content}`
 func prompt_gpt(ListOfMessages:Array[Message], model: String = "gpt-4o-mini", url:String="https://api.openai.com/v1/chat/completions", tools:Array = []):
@@ -34,6 +37,12 @@ func prompt_dalle(prompt:String, resolution:String = "1024x1024", model: String 
 		await get_tree().create_timer(0.2).timeout
 		
 	dalle.prompt_dalle(prompt,resolution,model,url)
+
+##Makes an api call to open ai embeddings, and returns the embedding array
+func get_embedding(input_text:String, model:String = "text-embedding-3-small", url:String="https://api.openai.com/v1/embeddings"):
+	while !embeddings:
+		await get_tree().create_timer(0.2).timeout
+	embeddings.get_embedding(input_text, model, url)
 
 func run_grader(grader_obj: Dictionary, model_sample, item = null, url: String = "https://api.openai.com/v1/fine_tuning/alpha/graders/run"):
 	while !grader:
@@ -66,16 +75,17 @@ func get_models() -> void:
 	models.get_available_models()
 
 func _ready():
-	if chatgpt and dalle and models and grader:
+	if chatgpt and dalle and models and grader and embeddings:
 		return
 
 	call_deferred("add_child", chatgpt_inst.instantiate())
 	call_deferred("add_child", dalle_inst.instantiate())
 	call_deferred("add_child", models_inst.instantiate())
 	call_deferred("add_child", grader_inst.instantiate())
+	call_deferred("add_child", embeddings_inst.instantiate())
 	
 func _process(delta):
-	if chatgpt and dalle and models and grader:
+	if chatgpt and dalle and models and grader and embeddings:
 		set_process(false)
 		return
 	for child in get_children():
@@ -87,3 +97,5 @@ func _process(delta):
 			models = child
 		elif !grader and child is Grader:
 			grader = child
+		elif !embeddings and child is Embeddings:
+			embeddings = child

--- a/addons/openai_api/Scripts/readme.md
+++ b/addons/openai_api/Scripts/readme.md
@@ -6,6 +6,7 @@ This plugin integrates OpenAI's GPT and DALL-E APIs into Godot, allowing easy ac
 
 - ChatGPT integration for text generation
 - DALL-E integration for image generation
+- Embeddings API for vector generation
 - Asynchronous API calls using Godot's HTTPRequest
 - Easy-to-use Message class for handling conversation context
 - Support for OpenAI graders API
@@ -65,6 +66,24 @@ func _on_dalle_response(texture: ImageTexture):
 	$Sprite2D.texture = texture
 ```
 
+
+### Using Embeddings
+
+To generate an embedding vector from text:
+
+```gdscript
+openai.get_embedding("A sample sentence")
+```
+
+Listen for the response:
+
+```gdscript
+func _ready():
+	openai.embedding_received.connect(self._on_embedding)
+
+func _on_embedding(embedding: Array, response: Dictionary):
+	print(embedding)
+```
 ## Classes
 
 ### OpenAI

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -1,8 +1,19 @@
 import subprocess
 import sys
 
-cmd = ['godot', '--headless', '-s', 'tests/test_grader.gd']
-print('Running:', ' '.join(cmd))
-result = subprocess.run(cmd)
-print('Godot exited with', result.returncode)
-sys.exit(result.returncode)
+
+def run(cmd):
+    print('Running:', ' '.join(cmd))
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print('Godot exited with', result.returncode)
+        sys.exit(result.returncode)
+
+# Start editor in headless mode to avoid import errors
+run(['godot', '-e', '--headless', '--quit-after', '2'])
+
+# Run tests
+run(['godot', '--headless', '-s', 'tests/test_grader.gd'])
+run(['godot', '--headless', '-s', 'tests/test_embeddings.gd'])
+
+print('All tests passed')

--- a/tests/test_embeddings.gd
+++ b/tests/test_embeddings.gd
@@ -1,0 +1,31 @@
+extends SceneTree
+class FakeParent:
+	extends Node
+	var api_key = ""
+	signal embedding_received(embedding: Array, response: Dictionary)
+	func get_api():
+		return api_key
+var EmbeddingsScript = load("res://addons/openai_api/Scripts/Embeddings.gd")
+var parent_node : FakeParent
+var embeddings
+func _initialize():
+	var key = OS.get_environment("OPENAI_API_KEY")
+	if key == "":
+		print("Skipping embeddings tests: OPENAI_API_KEY not set")
+		quit(0)
+		return
+	parent_node = FakeParent.new()
+	parent_node.api_key = key
+	get_root().add_child(parent_node)
+	embeddings = EmbeddingsScript.new()
+	parent_node.add_child(embeddings)
+	await self.process_frame
+	parent_node.embedding_received.connect(_on_embedding)
+	embeddings.get_embedding("Test embedding")
+func _on_embedding(embedding: Array, response: Dictionary) -> void:
+	if embedding.size() == 0:
+		push_error("Embedding is empty")
+		quit(1)
+		return
+	print("Embedding received")
+	quit(0)


### PR DESCRIPTION
## Summary
- add Embeddings node and helper to request text embeddings
- expose `get_embedding` in `OpenAiApi` and document usage
- add basic embedding test and run script updates

## Testing
- `godot -e --headless --quit-after 2`
- `OPENAI_API_KEY= godot --headless -s tests/test_grader.gd`
- `OPENAI_API_KEY= godot --headless -s tests/test_embeddings.gd`


------
https://chatgpt.com/codex/tasks/task_e_68a42e77cab08320b8dc9bf4a9e9fc78